### PR TITLE
fix: empty symbol

### DIFF
--- a/demo/about.html
+++ b/demo/about.html
@@ -27,6 +27,6 @@
     </body>
 
     <script src="src/js/script.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/sagemodeninja/fluent-icon-element-component@v1.0.1/src/fluent-icon-element.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/sagemodeninja/fluent-icon-element-component@v1.0.2/src/fluent-icon-element.min.js"></script>
     <script src="../src/fluent-navigation-view.js"></script>
 </html>

--- a/demo/contact.html
+++ b/demo/contact.html
@@ -27,6 +27,6 @@
     </body>
 
     <script src="src/js/script.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/sagemodeninja/fluent-icon-element-component@v1.0.1/src/fluent-icon-element.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/sagemodeninja/fluent-icon-element-component@v1.0.2/src/fluent-icon-element.min.js"></script>
     <script src="../src/fluent-navigation-view.js"></script>
 </html>

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,7 +10,7 @@
     <body>
         <fluent-navigation-view id="navigation_view" header="Home" pane-display-mode="left" header-src="tag" selects-on-load>
             <fluent-navigation-view-menu-items>
-                <fluent-navigation-view-item icon="Home" content="Home" tag="Home" href="index.html">
+                <fluent-navigation-view-item content="Home" tag="Home" href="index.html">
                     <fluent-font-icon glyph="&#xE80F;" slot="icon"></fluent-font-icon>
                 </fluent-navigation-view-item>
                 <fluent-navigation-view-item-header content="Pages"></fluent-navigation-view-item-header>
@@ -45,6 +45,6 @@
     </body>
 
     <script src="src/js/script.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/sagemodeninja/fluent-icon-element-component@v1.0.1/src/fluent-icon-element.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/sagemodeninja/fluent-icon-element-component@v1.0.2/src/fluent-icon-element.min.js"></script>
     <script src="../src/fluent-navigation-view.js"></script>
 </html>

--- a/src/fluent-navigation-view.js
+++ b/src/fluent-navigation-view.js
@@ -244,7 +244,7 @@
         }
 
         setIcon() {
-            this.iconSpan.setAttribute("symbol", this.icon);
+            this.iconSpan.setAttribute("symbol", this.icon ?? "");
         }
 
         select(selected) {


### PR DESCRIPTION
~Should now properly set an empty icon to default symbol when using custom icon.